### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/modules/nixosSystems/uranium/hardware/default.nix
+++ b/modules/nixosSystems/uranium/hardware/default.nix
@@ -76,7 +76,7 @@
     };
     udisks2.enable = true; # NOTE: fwupdmgr uses this to check the boot
   };
-  # pipewire config, from https://nixos.wiki/wiki/PipeWire
+  # pipewire config, from https://wiki.nixos.org/wiki/PipeWire
   security.rtkit.enable = true;
   environment.etc = {
     # battery management

--- a/new_project.org
+++ b/new_project.org
@@ -4341,7 +4341,7 @@ Imported [[(uranium-hw-import)][here]].
   # bluetooth
   hardware.bluetooth.enable = true;
   services.blueman.enable = true;
-  # pipewire config, from https://nixos.wiki/wiki/PipeWire
+  # pipewire config, from https://wiki.nixos.org/wiki/PipeWire
   security.rtkit.enable = true;
   services.pipewire = {
     enable = true;
@@ -4414,7 +4414,7 @@ Imported [[(uranium-hw-import)][here]].
   # Instead of archwiki, frame.work forums recommend this with s2idle
 
   # Hardware acceleration
-  # Taken from https://nixos.wiki/wiki/Accelerated_Video_Playback
+  # Taken from https://wiki.nixos.org/wiki/Accelerated_Video_Playback
   nixpkgs.config.packageOverrides = pkgs: {
     vaapiIntel = pkgs.vaapiIntel.override { enableHybridCodec = true; };
   };


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️